### PR TITLE
Fix global app export timing

### DIFF
--- a/app.js
+++ b/app.js
@@ -384,7 +384,6 @@ let app;
 window.addEventListener('DOMContentLoaded', async () => {
   app = new LicenceApp();
   await app.init();
+  // Export global après initialisation
+  window.app = app;
 });
-
-// Export global
-window.app = app;


### PR DESCRIPTION
## Summary
- fix bug where window.app was undefined because exported before init

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68679511e7fc832582f88d32a8f68bdd