### PR TITLE
Fix id comparison for edit/delete

### DIFF
--- a/app.js
+++ b/app.js
@@ -303,7 +303,7 @@ class LicenceApp {
 
   // Éditer une licence
   editLicence(id) {
-    const licence = this.licences.find(l => l.id === id);
+    const licence = this.licences.find(l => String(l.id) === String(id));
     if (licence) {
       this.openForm(licence);
     }
@@ -311,7 +311,7 @@ class LicenceApp {
 
   // Supprimer une licence
   async deleteLicence(id) {
-    const licence = this.licences.find(l => l.id === id);
+    const licence = this.licences.find(l => String(l.id) === String(id));
     if (!licence) return;
     
     if (!confirm(`Êtes-vous sûr de vouloir supprimer la licence "${licence.softwareName}" ?`)) {
@@ -384,7 +384,6 @@ let app;
 window.addEventListener('DOMContentLoaded', async () => {
   app = new LicenceApp();
   await app.init();
+  // Export global après initialisation
+  window.app = app;
 });
-
-// Export global
-window.app = app;


### PR DESCRIPTION
## Summary
- ensure edit/delete find licences regardless of id type

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68679511e7fc832582f88d32a8f68bdd