### PR TITLE
Fix Auth init call

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,9 +242,13 @@
     <script>
       document.addEventListener("DOMContentLoaded", async () => {
         try {
-          await Auth.init();
+          if (window.Auth && typeof window.Auth.init === 'function') {
+            await window.Auth.init();
+          } else {
+            throw new Error('Module Auth non chargé');
+          }
         } catch (err) {
-          console.error("Erreur init Auth", err);
+          console.error('Erreur init Auth', err);
         }
 
         const loginPage = document.getElementById("loginPage");


### PR DESCRIPTION
## Summary
- avoid calling Auth.init when the module isn't loaded

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6867a5bc3a7c8325b336c0454d935d9d